### PR TITLE
Fix exception caused by assumption that all issues are assigned

### DIFF
--- a/src/jetbrains/macros/IssueHighlighter.java
+++ b/src/jetbrains/macros/IssueHighlighter.java
@@ -63,8 +63,24 @@ public class IssueHighlighter extends YouTrackAuthAwareMacroBase {
                         context.put("issue", issueId);
                         context.put("summary", issue.getSummary());
                         context.put("style", (issue.isResolved()) ? "line-through" : "normal");
-                        context.put("title", MessageFormat.format("Reporter: {0}, Priority: {1},  State: {2}, Assignee: {3}, Votes: {4}, Type: {5}",
-                                issue.getReporter(), issue.getPriority(), issue.getState(), issue.getAssignee().getFullName(), issue.getVotes(), issue.getType()));
+
+                        StringBuilder titleContext = new StringBuilder();
+                        titleContext.append("Reporter: ").append(issue.getReporter());
+                        titleContext.append(", Priority: ").append(issue.getPriority());
+                        titleContext.append(", State: ").append(issue.getState());
+                        titleContext.append(", Assignee: ");
+
+                        try {
+                            titleContext.append(issue.getAssignee().getFullName());
+                        } catch (Exception ex) {
+                            titleContext.append("Unassigned");
+                        }
+
+                        titleContext.append(", Votes: ").append(issue.getVotes());
+                        titleContext.append(", Type: ").append(issue.getType());
+
+                        context.put("title", titleContext.toString());
+
                         final User currentUser = AuthenticatedUserThreadLocal.get();
                         if (currentUser != null) {
                             context.put("user", currentUser.getFullName());

--- a/src/jetbrains/macros/IssueReport.java
+++ b/src/jetbrains/macros/IssueReport.java
@@ -60,7 +60,13 @@ public class IssueReport extends YouTrackAuthAwareMacroBase {
                         myContext.put("base", baseHost.replace("/rest/", ""));
                         myContext.put("state", issue.getState());
                         myContext.put("summary", issue.getSummary());
-                        myContext.put("assignee", issue.getAssignee().getFullName());
+
+                        try {
+                            myContext.put("assignee", issue.getAssignee().getFullName());
+                        } catch (Exception ex) {
+                            myContext.put("assignee", "Unassigned");
+                        }
+
                         rows.append(VelocityUtils.getRenderedTemplate(ROW, myContext));
                     }
                     String report = "<p>{0}</p>\n" +


### PR DESCRIPTION
YouTrackRestApi throws an exception when attempting to access fields which don't exist -- an unassigned issue won't have the "assignee" field. The error left unchecked resulted in the following text in Confluence in place of the issue ID:

>Error rendering macro 'issue' : com.atlassian.renderer.v2.macro.MacroException: youtrack.exceptions.NoSuchIssueFieldException: Issue null has no field: Assignee

I tested against the master branch but applied the fix to the 5.6.1-api instead since I see that it's further along.