### PR TITLE
It closes #18 and #20 issues i reported

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/out
+/.idea/workspace.xml

--- a/.idea/ant.xml
+++ b/.idea/ant.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AntConfiguration">
+    <buildFile url="file://$PROJECT_DIR$/build-plugin.xml" />
+  </component>
+</project>

--- a/src/jetbrains/macros/IssueLink.java
+++ b/src/jetbrains/macros/IssueLink.java
@@ -63,6 +63,11 @@ public class IssueLink extends YouTrackAuthAwareMacroBase {
                     }
                     context.put(Strings.ISSUE, issueId);
                     context.put(Strings.BASE, getProperty(Strings.HOST).replace(Strings.REST_PREFIX, Strings.EMPTY));
+                    context.put(Strings.LINKBASE, getProperty(Strings.HOST).replace(Strings.REST_PREFIX, Strings.EMPTY));
+                    String linkbase = getProperty(Strings.LINKBASE);
+                    if(null!=linkbase && !linkbase.isEmpty()){
+                        context.put(Strings.LINKBASE,linkbase.replace(Strings.REST_PREFIX, Strings.EMPTY));
+                    }
                     final String thru = (Strings.ALL.equals(strikeMode) || Strings.ID_ONLY.equals(strikeMode)) && issue.isResolved() ? "line-through" : Strings.NORMAL;
                     if (Strings.ID_ONLY.equals(strikeMode)) {
                         linkTextTemplate = linkTextTemplate.replace("$issue", MessageFormat.format(Strings.STRIKE_THRU, thru, "$issue"));

--- a/src/jetbrains/macros/IssueReport.java
+++ b/src/jetbrains/macros/IssueReport.java
@@ -115,10 +115,15 @@ public class IssueReport extends YouTrackAuthAwareMacroBase {
 
                     myContext.put(Strings.STYLE, (issue.isResolved()) ? "line-through" : "normal");
                     myContext.put(Strings.BASE, getProperty(Strings.HOST).replace(Strings.REST_PREFIX, Strings.EMPTY));
+                    context.put(Strings.LINKBASE, getProperty(Strings.HOST).replace(Strings.REST_PREFIX, Strings.EMPTY));
+                    String linkbase = getProperty(Strings.LINKBASE);
+                    if(null!=linkbase && !linkbase.isEmpty()){
+                        context.put(Strings.LINKBASE,linkbase.replace(Strings.REST_PREFIX, Strings.EMPTY));
+                    }
                     rows.append("<tr>");
                     rows.append("<td>");
                     rows.append(MessageFormat.format("<a  href=\"{0}/issue/{1}\" target=\"blank\" style=\"text-decoration:{2};\">{1}</a>",
-                            getProperty(Strings.HOST).replace(Strings.REST_PREFIX, Strings.EMPTY), sIssue.getId(), issue.isResolved() ? "line-through" : "normal"));
+                            context.get(Strings.LINKBASE), sIssue.getId(), issue.isResolved() ? "line-through" : "normal"));
                     rows.append("</td>");
                     for (final IssueFieldDescriptor desc : fields) {
                         rows.append("<td>");

--- a/src/jetbrains/macros/IssueReport.java
+++ b/src/jetbrains/macros/IssueReport.java
@@ -120,9 +120,9 @@ public class IssueReport extends YouTrackAuthAwareMacroBase {
                     if(null!=linkbase && !linkbase.isEmpty()){
                         context.put(Strings.LINKBASE,linkbase.replace(Strings.REST_PREFIX, Strings.EMPTY));
                     }
-                    rows.append("<tr>");
+                    rows.append("<tr class=\"yt yt-report-row\">");
                     rows.append("<td>");
-                    rows.append(MessageFormat.format("<a  href=\"{0}/issue/{1}\" target=\"blank\" style=\"text-decoration:{2};\">{1}</a>",
+                    rows.append(MessageFormat.format("<a class=\"yt yt-issuelink\" href=\"{0}/issue/{1}\" target=\"blank\" style=\"text-decoration:{2};\">{1}</a>",
                             context.get(Strings.LINKBASE), sIssue.getId(), issue.isResolved() ? "line-through" : "normal"));
                     rows.append("</td>");
                     for (final IssueFieldDescriptor desc : fields) {

--- a/src/jetbrains/macros/actions/ConfigurationServlet.java
+++ b/src/jetbrains/macros/actions/ConfigurationServlet.java
@@ -65,6 +65,7 @@ public class ConfigurationServlet extends HttpServlet {
         final String password = req.getParameter(Strings.PASSWORD);
         final String login = req.getParameter(Strings.LOGIN);
         final String retries = req.getParameter(Strings.RETRIES);
+        final String linkbase = req.getParameter(Strings.LINKBASE);
         final YouTrack testYouTrack = YouTrack.getInstance(hostAddress);
         try {
             testYouTrack.login(login, password);
@@ -77,6 +78,7 @@ public class ConfigurationServlet extends HttpServlet {
                     storage.setProperty(Strings.LOGIN, login);
                     storage.setProperty(Strings.RETRIES, intValueOf(retries, 10));
                     storage.setProperty(Strings.PASSWORD, password);
+                    storage.setProperty(Strings.LINKBASE, linkbase);
                     storage.setProperty(Strings.AUTH_KEY, testYouTrack.getAuthorization());
                     pluginSettings.put(Strings.MAIN_KEY, storage);
                     return null;
@@ -119,6 +121,7 @@ public class ConfigurationServlet extends HttpServlet {
         params.put(Strings.RETRIES, storage.getProperty(Strings.RETRIES, "10"));
         params.put(Strings.PASSWORD, storage.getProperty(Strings.PASSWORD, Strings.EMPTY));
         params.put(Strings.LOGIN, storage.getProperty(Strings.LOGIN, Strings.EMPTY));
+        params.put(Strings.LINKBASE, storage.getProperty(Strings.LINKBASE, Strings.EMPTY));
         params.put("justSaved", justSaved);
         justSaved = -1;
         response.setContentType("text/html;charset=utf-8");

--- a/src/jetbrains/macros/util/Strings.java
+++ b/src/jetbrains/macros/util/Strings.java
@@ -9,6 +9,7 @@ public class Strings {
     public static final String STRIKE_THRU_PARAM = "strikethru-resolved";
     public static final String ISSUE = "issue";
     public static final String BASE = "base";
+    public static final String LINKBASE = "linkbase";
     public static final String STATE = "state";
     public static final String STRIKE_THRU = "<span style=\"text-decoration:{0};\">{1}</span>";
     public static final String SUMMARY = "summary";

--- a/src/main/resources/atlassian-plugin.xml
+++ b/src/main/resources/atlassian-plugin.xml
@@ -4,7 +4,7 @@
         <description>Plugin that enables integration between Confluence and YouTrack via macros that allow inserting
             dynamic links and query-based reports.
         </description>
-        <version>1.7.0.13</version>
+        <version>1.7.0.14</version>
         <vendor name="JetBrains" url="http://www.jetbrains.com"/>
         <param name="configure.url">/plugins/servlet/youtrack-integration/settings</param>
     </plugin-info>

--- a/src/main/resources/templates/body-link-detailed.vm
+++ b/src/main/resources/templates/body-link-detailed.vm
@@ -1,7 +1,7 @@
 #if ($issue)
     #set($issueLinkTextWithHtml = $issueLinkText)
     #set($summaryWithHtml = $summaryFormattedText)
-<span>$summaryWithHtml</span>&nbsp;(<a href="$base/issue/$issue" target="_blank" title="$title">$issueLinkTextWithHtml</a>)
+<span>$summaryWithHtml</span>&nbsp;(<a href="$linkbase/issue/$issue" target="_blank" title="$title">$issueLinkTextWithHtml</a>)
 #else
 <span style="color:darkred;background-color:lightgrey">$error</span>
 #end

--- a/src/main/resources/templates/body-link-detailed.vm
+++ b/src/main/resources/templates/body-link-detailed.vm
@@ -1,7 +1,9 @@
+<span class="yt yt-issue yt-issue-detailed">
 #if ($issue)
     #set($issueLinkTextWithHtml = $issueLinkText)
     #set($summaryWithHtml = $summaryFormattedText)
-<span>$summaryWithHtml</span>&nbsp;(<a href="$linkbase/issue/$issue" target="_blank" title="$title">$issueLinkTextWithHtml</a>)
+<span class="yt yt-summary">$summaryWithHtml</span>&nbsp;(<a class="yt yt-issuelink" href="$linkbase/issue/$issue" target="_blank" title="$title">$issueLinkTextWithHtml</a>)
 #else
-<span style="color:darkred;background-color:lightgrey">$error</span>
+<span class="yt yt-error" style="color:darkred;background-color:lightgrey">$error</span>
 #end
+</span>

--- a/src/main/resources/templates/body-link-short.vm
+++ b/src/main/resources/templates/body-link-short.vm
@@ -1,6 +1,8 @@
+<span class="yt yt-issue yt-issue-short">
 #if ($issue)
     #set($issueLinkTextWithHtml = $issueLinkText)
-<a href="$linkbase/issue/$issue" target="_blank" title="$title">$issueLinkTextWithHtml</a>
+<a  class="yt yt-issuelink"  href="$linkbase/issue/$issue" target="_blank" title="$title">$issueLinkTextWithHtml</a>
 #else
 <span style="color:darkred;background-color:lightgrey">$error</span>
 #end
+</span>

--- a/src/main/resources/templates/body-link-short.vm
+++ b/src/main/resources/templates/body-link-short.vm
@@ -1,6 +1,6 @@
 #if ($issue)
     #set($issueLinkTextWithHtml = $issueLinkText)
-<a href="$base/issue/$issue" target="_blank" title="$title">$issueLinkTextWithHtml</a>
+<a href="$linkbase/issue/$issue" target="_blank" title="$title">$issueLinkTextWithHtml</a>
 #else
 <span style="color:darkred;background-color:lightgrey">$error</span>
 #end

--- a/src/main/resources/templates/body-report.vm
+++ b/src/main/resources/templates/body-report.vm
@@ -1,3 +1,4 @@
+<div class="yt yt-report">
 <h3>$title</h3>
 #set($headerWithHtml =$header)
 #set($rowsWithHtml = $rows)
@@ -15,3 +16,4 @@
 <p>
     $paginationWithHtml
 </p>
+</div>

--- a/src/main/resources/templates/settings-servlet.vm
+++ b/src/main/resources/templates/settings-servlet.vm
@@ -24,6 +24,10 @@
         <input type="password" name="password" id="password" class="text" value="$password">
     </div>
     <div class="field-group">
+        <label for="youtracklinkbase">Link base:</label>
+        <input type="linkbase" name="linkbase" id="linkbase" class="text" value="$linkbase">
+    </div>
+    <div class="field-group">
         <input type="submit" value="Save Settings" class="button">
     </div>
     #if ($justSaved==0)


### PR DESCRIPTION
1. Alternate URL for href's (another than backend link)
2. Wrappers with classes in "bootstrap" style "yt yt-issue-short" and so on - so now you can define styles for them with usual confluence tools